### PR TITLE
Global review

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "io.buildo"
 
-name := "spray-autoproductformat"
+name          := "spray-autoproductformat"
 
 version       := "0.3.0"
 
@@ -12,12 +12,10 @@ scalacOptions := Seq("-unchecked",
                      "-encoding", "utf8")
 
 libraryDependencies ++= Seq(
-  "io.spray"            %%  "spray-json"      % "1.2.6",
-  "org.scala-lang"      %   "scala-reflect"   % "2.11.0",
-  "org.scalatest"  %% "scalatest"     % "2.2.0" % "test",
-  "org.mockito"    %  "mockito-all"   % "1.9.5" % "test"
+  "io.spray"        %% "spray-json"     % "1.2.6",
+  "org.scala-lang"  %  "scala-reflect"  % "2.11.0",
+  "org.scalatest"   %% "scalatest"      % "2.2.0" % "test",
+  "org.mockito"     %  "mockito-all"    % "1.9.5" % "test"
 )
 
 publishTo := Some(Resolver.file("file", new File("releases")))
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions := Seq("-unchecked",
                      "-encoding", "utf8")
 
 libraryDependencies ++= Seq(
-  "io.spray"        %% "spray-json"     % "1.2.6",
+  "io.spray"        %% "spray-json"     % "1.3.2",
   "org.scala-lang"  %  "scala-reflect"  % "2.11.0",
   "org.scalatest"   %% "scalatest"      % "2.2.0" % "test",
   "org.mockito"     %  "mockito-all"    % "1.9.5" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name          := "spray-autoproductformat"
 
 version       := "0.3.0"
 
-scalaVersion  := "2.11.6"
+scalaVersion  := "2.11.7"
 
 scalacOptions := Seq("-unchecked",
                      "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization  := "io.buildo"
 
 name          := "spray-autoproductformat"
 
-version       := "0.3.0"
+version       := "0.4.0"
 
 scalaVersion  := "2.11.7"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/src/main/scala/spray/json/AutoProductFormat.scala
+++ b/src/main/scala/spray/json/AutoProductFormat.scala
@@ -4,7 +4,7 @@ import scala.language.experimental.macros
 
 trait AutoProductFormat {
   def autoProductSerialize[T <: Product]: RootJsonFormat[T] =
-      macro AutoProductFormatMacro.autoProductFormatMacro[T]
+    macro AutoProductFormatMacro.autoProductFormatMacro[T]
 }
 
 trait LargeProductFormat[A <: Product] {

--- a/src/main/scala/spray/json/AutoProductFormat.scala
+++ b/src/main/scala/spray/json/AutoProductFormat.scala
@@ -2,10 +2,8 @@ package spray.json
 
 import scala.language.experimental.macros
 
-trait AutoProductFormattable[T <: Product]
-
 trait AutoProductFormat {
-  implicit def jsonFormat[T <: Product](implicit apf: AutoProductFormattable[T]): RootJsonFormat[T] =
+  def autoProductSerialize[T <: Product]: RootJsonFormat[T] =
       macro AutoProductFormatMacro.autoProductFormatMacro[T]
 }
 
@@ -18,7 +16,7 @@ object AutoProductFormat extends AutoProductFormat
 object AutoProductFormatMacro {
   import scala.reflect.macros.blackbox.Context
 
-  def autoProductFormatMacro[T <: Product : c.WeakTypeTag](c: Context)(apf: c.Expr[AutoProductFormattable[T]]): c.Tree = {
+  def autoProductFormatMacro[T <: Product : c.WeakTypeTag](c: Context): c.Tree = {
     import c.universe._
 
     val tt = weakTypeTag[T]

--- a/src/test/scala/spray/json/AutoProductFormat.scala
+++ b/src/test/scala/spray/json/AutoProductFormat.scala
@@ -9,12 +9,11 @@ class AutoProductFormatSpec extends WordSpec with Matchers {
   // Test for compilation
   "AutoProductFormatMacro" should {
     "work with higher-kinded types" in {
-      implicit object ThingAutoProductFormattable extends AutoProductFormattable[Thing]
       implicit def labOnlineIdFormat[T <: ID[_]] = new JsonFormat[T] {
         def write(id: T) = ???
         def read(idRep: JsValue): T = ???
       }
-      "AutoProductFormat.jsonFormat[Thing]" should compile
+      "AutoProductFormat.autoProductSerialize[Thing]" should compile
     }
   }
 }


### PR DESCRIPTION
Removed `AutoProductFormattable` trait.
Replaced implicit `RootJsonFormat[T]` derivation with explicit `autoProductSerialize[T]` method call.
